### PR TITLE
State of asynchronous JS: async/await working in the browser (Chrome v 47) with only regenerator/runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.0",
     "grunt-browserify": "^3.6.0",
+    "grunt-cli": "^0.1.13",
     "load-grunt-tasks": "^3.1.0"
   },
   "dependencies": {

--- a/src/core.js
+++ b/src/core.js
@@ -1,1 +1,4 @@
-require('grunt-babel/node_modules/babel-core/polyfill');
+//require('babel-core/polyfill');
+
+//require('core-js/modules/es6.promise');
+require("regenerator/runtime");


### PR DESCRIPTION
I meant this to be more informational than a necessary merge. This pull shows that async/await can be run in modern browsers with minimal bundle size (only need regenerator/runtime). The babel-core/polyfill includes core-js/shim, which adds an entire ES6 environment--it is usually better to pick and choose which modules you will need from core-js for your target browser. 
See: https://kangax.github.io/compat-table/es6/
See: https://github.com/zloirock/core-js
